### PR TITLE
Fix typescript build by adding static types dependency list

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,9 +13,10 @@
     "rootDir": "src",
     "strict": true,
     "forceConsistentCasingInFileNames": true,
-    "importHelpers": true
+    "importHelpers": true,
     // enable this when it works with tslint, or we switch to prettier
     // "declarationMap": true
+    "types": ["js-yaml", "node", "request", "underscore", "ws", "byline", "chai", "chai-as-promised", "mocha", "mock-fs", "stream-buffers"]
   },
   "exclude": [
     "node_modules",


### PR DESCRIPTION
By default typescript tries to build any given types available in its build scope but that brings some issue when the consumer project import types dependencies because tsc would then try to compile them as well whereas they should remains out of the build scope of the library. 

In order to solve this I've statically listed all types dependencies of this project in the types attribute of ts config file.